### PR TITLE
Use dns-operator-route53

### DIFF
--- a/flux-manifests/dns-operator-route53.yaml
+++ b/flux-manifests/dns-operator-route53.yaml
@@ -1,0 +1,13 @@
+api_version: generators.giantswarm.io/v1
+app_catalog: control-plane-catalog
+app_destination_namespace: giantswarm
+app_name: dns-operator-route53
+app_version: 0.5.0
+kind: Konfigure
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      exec:
+        path: /plugins/konfigure
+  name: dns-operator-route53
+name: dns-operator-route53

--- a/flux-manifests/kustomization.yaml
+++ b/flux-manifests/kustomization.yaml
@@ -11,6 +11,7 @@ generators:
 - dashboards.yaml
 - deletion-blocker-operator.yaml
 - dex-app.yaml
+- dns-operator-route53.yaml
 - etcd-backup-operator.yaml
 - falco-app.yaml
 - fluent-logshipping-app.yaml


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1247

Tested in erkant2 cluster with 
- https://github.com/giantswarm/cloud-director-app-collection/commit/2e587ff2b9ad74c53fe2966bcea8b352ef681adf
- https://github.com/giantswarm/config/commit/8495887dec72746bf7cd788d428e4d26e21b1294


Production config is already adapted. 