### PR TITLE
update components

### DIFF
--- a/flux-manifests/dns-operator-route53.yaml
+++ b/flux-manifests/dns-operator-route53.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: dns-operator-route53
-app_version: 0.5.0
+app_version: 0.6.2
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
* update dns-operator-route53:
  version 0.6 supports a local cache to reduce load on the aws route53 api