### PR TITLE
update cloud-director

### DIFF
--- a/flux-manifests/cluster-api-provider-cloud-director.yaml
+++ b/flux-manifests/cluster-api-provider-cloud-director.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api-provider-cloud-director
-app_version: 0.2.4
+app_version: 0.2.5
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
version 0.2.5 of cloud-director removes the build-in proxy implementation