### PR TITLE
Update main branch based on guppy

### DIFF
--- a/flux-manifests/cluster-apps-operator.yaml
+++ b/flux-manifests/cluster-apps-operator.yaml
@@ -1,8 +1,8 @@
 api_version: generators.giantswarm.io/v1
-app_catalog: control-plane-catalog
+app_catalog: control-plane-test-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-apps-operator
-app_version: 2.8.2
+app_version: 2.8.2-3245c43626a1fc90d35f5d01e3dfd075335fbed3
 kind: Konfigure
 metadata:
   annotations:

--- a/flux-manifests/kyverno-policies-connectivity.yaml
+++ b/flux-manifests/kyverno-policies-connectivity.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: kyverno-policies-connectivity
-app_version: 0.2.1
+app_version: 0.2.3
 kind: Konfigure
 metadata:
   annotations:

--- a/flux-manifests/kyverno-policies-dx.yaml
+++ b/flux-manifests/kyverno-policies-dx.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: kyverno-policies-dx
-app_version: 0.1.0
+app_version: 0.3.0
 kind: Konfigure
 metadata:
   annotations:

--- a/flux-manifests/kyverno-policies-observability.yaml
+++ b/flux-manifests/kyverno-policies-observability.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: kyverno-policies-observability
-app_version: 0.1.2
+app_version: 0.2.2
 kind: Konfigure
 metadata:
   annotations:

--- a/flux-manifests/kyverno-policies-ux.yaml
+++ b/flux-manifests/kyverno-policies-ux.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: kyverno-policies-ux
-app_version: 0.1.0
+app_version: 0.1.1
 kind: Konfigure
 metadata:
   annotations:

--- a/flux-manifests/kyverno-policies.yaml
+++ b/flux-manifests/kyverno-policies.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: kyverno-policies
-app_version: 0.17.1
+app_version: 0.18.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
We need these changes for CAPVCD clusters behind proxy. 

I opened PRs in repos of kyverno apps to update this collection automatically.

Regarding the cluster-apps-operator change, We need this PR  https://github.com/giantswarm/cluster-apps-operator/pull/316 It is already merged. The version here will be updated with the next release. 

I need this PR to be able to recreate guppy without any manual intervention. 