### PR TITLE
Set nginx version back to latest version

### DIFF
--- a/flux-manifests/nginx-ingress-controller-app.yaml
+++ b/flux-manifests/nginx-ingress-controller-app.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: giantswarm
 app_destination_namespace: kube-system
 app_name: nginx-ingress-controller-app
-app_version: 2.23.2
+app_version: 2.30.1
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
It seems the current version tagged as latest is an older one that didn't support some features we used for the LB so catalogBot downgraded the version.