### PR TITLE
Bump CAPI version to 1.14.0

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.7.0
+app_version: 1.14.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
CAPVCD version is updated in the collection and it supports our newest CAPI version. We are able to bump it now.

Towards https://github.com/giantswarm/giantswarm/issues/27464