### PR TITLE
add oauth2-proxy back

### DIFF
--- a/flux-manifests/kustomization.yaml
+++ b/flux-manifests/kustomization.yaml
@@ -32,6 +32,7 @@ generators:
 - logging-operator.yaml
 - loki.yaml
 - mimir.yaml
+- oauth2-proxy.yaml
 - observability-operator.yaml
 - organization-operator.yaml
 - prometheus-meta-operator.yaml

--- a/flux-manifests/oauth2-proxy.yaml
+++ b/flux-manifests/oauth2-proxy.yaml
@@ -1,0 +1,13 @@
+api_version: generators.giantswarm.io/v1
+app_catalog: control-plane-catalog
+app_destination_namespace: monitoring
+app_name: oauth2-proxy
+app_version: 2.14.0
+kind: Konfigure
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      exec:
+        path: /plugins/konfigure
+  name: oauth2-proxy
+name: oauth2-proxy


### PR DESCRIPTION
We need oauth2-proxy on CAPI MCs to be able to support OAuth2/OIDC workflows