### PR TITLE
rollback trivy to v0.13.1

### DIFF
--- a/flux-manifests/trivy.yaml
+++ b/flux-manifests/trivy.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: trivy
-app_version: 0.13.2
+app_version: 0.13.1
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
MCs are not up to date so we need to rollback this version on some collections due to a missing api-version