### PR TITLE
Update cluster-api to 3.0.0

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 2.0.0
+app_version: 3.0.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
This PR is updating CAPI Controller to v1.8, which includes supporting K8s v1.31