### PR TITLE
Update cluster-api-cleaner-cloud-director in kustomize

### DIFF
--- a/kustomize/cluster-api-cleaner-cloud-director.yaml
+++ b/kustomize/cluster-api-cleaner-cloud-director.yaml
@@ -20,4 +20,4 @@ spec:
     inCluster: true
   name: cluster-api-cleaner-cloud-director
   namespace: giantswarm
-  version: 0.5.0
+  version: 0.5.1


### PR DESCRIPTION
The app wasn't upgraded in the clusters. I believe because of this.

Context: https://gigantic.slack.com/archives/CLPMFRVU6/p1748239460571149